### PR TITLE
Fix WiFi frame type detection logic

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -502,7 +502,7 @@ void wifi_sniffer_packet_handler(void* buff, wifi_promiscuous_pkt_type_t type)
     
     // Check for probe requests (subtype 0x04) and beacons (subtype 0x08)
     uint8_t frame_type = (hdr->frame_ctrl & 0xFF) >> 2;
-    if (frame_type != 0x20 && frame_type != 0x80) { // Probe request or beacon
+    if (frame_type != 0x10 && frame_type != 0x20) { // Probe request (0x10) or beacon (0x20)
         return;
     }
     
@@ -510,7 +510,7 @@ void wifi_sniffer_packet_handler(void* buff, wifi_promiscuous_pkt_type_t type)
     char ssid[33] = {0};
     uint8_t *payload = (uint8_t *)ipkt + 24; // Skip MAC header
     
-    if (frame_type == 0x20) { // Probe request
+    if (frame_type == 0x10) { // Probe request
         payload += 0; // Probe requests start with SSID immediately
     } else { // Beacon frame
         payload += 12; // Skip fixed parameters in beacon
@@ -524,7 +524,7 @@ void wifi_sniffer_packet_handler(void* buff, wifi_promiscuous_pkt_type_t type)
     
     // Check if SSID matches our patterns
     if (strlen(ssid) > 0 && check_ssid_pattern(ssid)) {
-        const char* detection_type = (frame_type == 0x20) ? "probe_request" : "beacon";
+        const char* detection_type = (frame_type == 0x10) ? "probe_request" : "beacon";
         output_wifi_detection_json(ssid, hdr->addr2, ppkt->rx_ctrl.rssi, detection_type);
         
         if (!triggered) {
@@ -538,7 +538,7 @@ void wifi_sniffer_packet_handler(void* buff, wifi_promiscuous_pkt_type_t type)
     
     // Check MAC address
     if (check_mac_prefix(hdr->addr2)) {
-        const char* detection_type = (frame_type == 0x20) ? "probe_request_mac" : "beacon_mac";
+        const char* detection_type = (frame_type == 0x10) ? "probe_request_mac" : "beacon_mac";
         output_wifi_detection_json(ssid[0] ? ssid : "hidden", hdr->addr2, ppkt->rx_ctrl.rssi, detection_type);
         
         if (!triggered) {


### PR DESCRIPTION
Fix 802.11 frame type values in the WiFi sniffer packet handler. Probe requests were being filtered out and beacon frames were mislabeled.

Fixes #15