### PR TITLE
Add T-Dongle S3 display and RGB LED support

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -24,10 +24,34 @@ board_build.partitions = huge_app.csv
 board_build.flash_mode = qio
 board_build.flash_size = 4MB
 board_build.psram_type = opi
-lib_deps = 
+lib_deps =
     h2zero/NimBLE-Arduino@^1.4.0
     bblanchon/ArduinoJson@^6.21.0
-build_flags = 
+build_flags =
     -DARDUINO_USB_MODE=1
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DCONFIG_BT_NIMBLE_ENABLED=1
+
+[env:t_dongle_s3]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_speed = 115200
+board_build.partitions = huge_app.csv
+board_build.flash_mode = qio
+board_build.flash_size = 16MB
+board_build.psram_type = opi
+lib_deps =
+    h2zero/NimBLE-Arduino@^1.4.0
+    bblanchon/ArduinoJson@^6.21.0
+    adafruit/Adafruit ST7735 and ST7789 Library@^1.10.0
+    adafruit/Adafruit GFX Library@^1.11.0
+    fastled/FastLED@^3.6.0
+build_flags =
+    -DARDUINO_USB_MODE=1
+    -DARDUINO_USB_CDC_ON_BOOT=1
+    -DCONFIG_BT_NIMBLE_ENABLED=1
+    -DBOARD_T_DONGLE_S3=1
+    ; APA102 RGB LED pins
+    -DLED_DATA_PIN=40
+    -DLED_CLOCK_PIN=39

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -1,0 +1,244 @@
+// Only compile for T-Dongle S3
+#ifdef BOARD_T_DONGLE_S3
+
+#include "display.h"
+
+#include <Adafruit_GFX.h>
+#include <Adafruit_ST7735.h>
+#include <SPI.h>
+
+#define DEVICE_NAME "T-Dongle S3"
+
+// T-Dongle S3 Display pins
+#define TFT_CS     4
+#define TFT_RST    1
+#define TFT_DC     2
+#define TFT_MOSI   3
+#define TFT_SCLK   5
+#define TFT_BL     38
+
+// Use HSPI
+static SPIClass hspi(HSPI);
+static Adafruit_ST7735 tft = Adafruit_ST7735(&hspi, TFT_CS, TFT_DC, TFT_RST);
+
+// State tracking
+static DisplayState current_state = DISPLAY_BOOT;
+static unsigned long last_update = 0;
+static bool flash_state = false;
+
+// Detection info storage
+static char det_type[32] = {0};
+static char det_name[32] = {0};
+static char det_mac[24] = {0};
+static int det_threat = 0;
+
+// Cool color scheme
+#define COLOR_BG        ST77XX_BLACK
+#define COLOR_TITLE_BG  0x0018  // Deep blue-purple
+#define COLOR_TITLE_FG  ST77XX_CYAN
+#define COLOR_TEXT      ST77XX_WHITE
+#define COLOR_SCANNING  ST77XX_CYAN
+#define COLOR_ALERT_BG  0xF800  // Bright red
+#define COLOR_ALERT_FG  ST77XX_WHITE
+#define COLOR_HEARTBEAT ST77XX_MAGENTA
+#define COLOR_ACCENT    0x07FF  // Cyan
+#define COLOR_WARN      0xFBE0  // Orange-yellow
+
+void display_init() {
+    // Turn on backlight first (active LOW on T-Dongle S3)
+    pinMode(TFT_BL, OUTPUT);
+    digitalWrite(TFT_BL, LOW);  // LOW = ON
+
+    // Initialize SPI for display
+    hspi.begin(TFT_SCLK, -1, TFT_MOSI, TFT_CS);
+
+    // Initialize ST7735 display with correct variant
+    tft.initR(INITR_MINI160x80_PLUGIN);
+    tft.setRotation(1);  // Landscape (160x80)
+    tft.fillScreen(COLOR_BG);
+}
+
+void display_boot_screen() {
+    current_state = DISPLAY_BOOT;
+    tft.fillScreen(COLOR_BG);
+
+    // Title bar with gradient effect (just solid for now)
+    tft.fillRect(0, 0, 160, 16, COLOR_TITLE_BG);
+    tft.setTextColor(COLOR_TITLE_FG);
+    tft.setTextSize(1);
+    tft.setCursor(4, 4);
+    tft.print("FLOCK YOU");
+
+    // Version badge
+    tft.setCursor(100, 4);
+    tft.setTextColor(ST77XX_MAGENTA);
+    tft.print("v1.0");
+
+    // Device info
+    tft.setTextColor(COLOR_ACCENT);
+    tft.setCursor(4, 24);
+    tft.print(DEVICE_NAME);
+
+    tft.setCursor(4, 38);
+    tft.setTextColor(COLOR_WARN);
+    tft.print("Initializing...");
+
+    tft.setCursor(4, 56);
+    tft.setTextColor(ST77XX_CYAN);
+    tft.print("WiFi + BLE Scanner");
+
+    last_update = millis();
+}
+
+void display_scanning(uint8_t wifi_channel, bool ble_active) {
+    if (current_state == DISPLAY_DETECTION) {
+        return;  // Don't overwrite active detection
+    }
+
+    current_state = DISPLAY_SCANNING;
+
+    // Clear main area (keep title)
+    tft.fillRect(0, 16, 160, 64, COLOR_BG);
+
+    // Title bar
+    tft.fillRect(0, 0, 160, 16, COLOR_TITLE_BG);
+    tft.setTextColor(COLOR_TITLE_FG);
+    tft.setTextSize(1);
+    tft.setCursor(4, 4);
+    tft.print("FLOCK YOU");
+
+    // Scanning indicator with cool styling
+    tft.setTextColor(ST77XX_CYAN);
+    tft.setTextSize(2);
+    tft.setCursor(4, 20);
+    tft.print("SCANNING");
+
+    // Animated dots area (static for now)
+    tft.setTextColor(ST77XX_MAGENTA);
+    tft.print("...");
+
+    // Status line with icons
+    tft.setTextSize(1);
+    tft.setCursor(4, 46);
+    tft.setTextColor(COLOR_WARN);
+    tft.print("WiFi:");
+    tft.setTextColor(ST77XX_WHITE);
+    tft.print(" Ch ");
+    tft.setTextColor(ST77XX_CYAN);
+    tft.print(wifi_channel);
+
+    tft.setCursor(80, 46);
+    tft.setTextColor(COLOR_WARN);
+    tft.print("BLE:");
+    tft.setTextColor(ble_active ? ST77XX_GREEN : ST77XX_RED);
+    tft.print(ble_active ? " ON" : " --");
+
+    // Bottom status
+    tft.setCursor(4, 64);
+    tft.setTextColor(0x4208);  // Dark gray
+    tft.print("Hunting Flock cameras...");
+
+    last_update = millis();
+}
+
+void display_detection(const char* type, const char* name, const char* mac, int threat_score) {
+    current_state = DISPLAY_DETECTION;
+    flash_state = true;
+
+    // Store detection info
+    strncpy(det_type, type, sizeof(det_type) - 1);
+    strncpy(det_name, name, sizeof(det_name) - 1);
+    strncpy(det_mac, mac, sizeof(det_mac) - 1);
+    det_threat = threat_score;
+
+    // Alert screen
+    tft.fillScreen(COLOR_ALERT_BG);
+
+    // Title bar (red alert)
+    tft.setTextColor(COLOR_ALERT_FG);
+    tft.setTextSize(1);
+    tft.setCursor(4, 2);
+    tft.print("!! DETECTED !!");
+
+    // Detection type
+    tft.setCursor(4, 16);
+    tft.print(type);
+
+    // Device name (truncate if needed)
+    tft.setCursor(4, 30);
+    if (strlen(name) > 20) {
+        char truncated[21];
+        strncpy(truncated, name, 20);
+        truncated[20] = '\0';
+        tft.print(truncated);
+    } else {
+        tft.print(name);
+    }
+
+    // MAC address
+    tft.setCursor(4, 44);
+    tft.setTextColor(ST77XX_YELLOW);
+    tft.print(mac);
+
+    // Threat score
+    tft.setCursor(4, 62);
+    tft.setTextColor(COLOR_ALERT_FG);
+    tft.print("Threat: ");
+    tft.print(threat_score);
+    tft.print("%");
+
+    last_update = millis();
+}
+
+void display_heartbeat() {
+    if (current_state != DISPLAY_DETECTION) {
+        return;
+    }
+
+    // Flash the title to indicate device still in range
+    flash_state = !flash_state;
+
+    if (flash_state) {
+        tft.fillRect(0, 0, 160, 14, COLOR_HEARTBEAT);
+        tft.setTextColor(COLOR_BG);
+    } else {
+        tft.fillRect(0, 0, 160, 14, COLOR_ALERT_BG);
+        tft.setTextColor(COLOR_ALERT_FG);
+    }
+
+    tft.setTextSize(1);
+    tft.setCursor(4, 2);
+    tft.print("!! IN RANGE !!");
+}
+
+void display_clear_detection() {
+    current_state = DISPLAY_SCANNING;
+    det_type[0] = '\0';
+    det_name[0] = '\0';
+    det_mac[0] = '\0';
+    det_threat = 0;
+}
+
+void display_update() {
+    // Periodic update for animations/refresh
+    unsigned long now = millis();
+
+    if (current_state == DISPLAY_DETECTION) {
+        // Flash effect during detection
+        if (now - last_update >= 500) {
+            flash_state = !flash_state;
+            if (flash_state) {
+                tft.fillRect(0, 0, 160, 14, COLOR_ALERT_BG);
+            } else {
+                tft.fillRect(0, 0, 160, 14, COLOR_HEARTBEAT);
+            }
+            tft.setTextColor(COLOR_ALERT_FG);
+            tft.setTextSize(1);
+            tft.setCursor(4, 2);
+            tft.print("!! DETECTED !!");
+            last_update = now;
+        }
+    }
+}
+
+#endif // BOARD_T_DONGLE_S3

--- a/src/display.h
+++ b/src/display.h
@@ -1,0 +1,38 @@
+#ifndef DISPLAY_H
+#define DISPLAY_H
+
+// Display module for T-Dongle S3 only
+// This file is only included when BOARD_T_DONGLE_S3 is defined
+
+#include <Arduino.h>
+
+// Display states
+enum DisplayState {
+    DISPLAY_BOOT,
+    DISPLAY_SCANNING,
+    DISPLAY_DETECTION,
+    DISPLAY_HEARTBEAT
+};
+
+// Initialize the TFT display
+void display_init();
+
+// Show boot screen with device info
+void display_boot_screen();
+
+// Show scanning status with channel info
+void display_scanning(uint8_t wifi_channel, bool ble_active);
+
+// Show detection alert
+void display_detection(const char* type, const char* name, const char* mac, int threat_score);
+
+// Show heartbeat indicator (device still in range)
+void display_heartbeat();
+
+// Clear detection and return to scanning
+void display_clear_detection();
+
+// Update display (call periodically from loop)
+void display_update();
+
+#endif // DISPLAY_H

--- a/src/rgb_led.cpp
+++ b/src/rgb_led.cpp
@@ -1,0 +1,133 @@
+// Only compile for T-Dongle S3
+#ifdef BOARD_T_DONGLE_S3
+
+#include "rgb_led.h"
+
+#include <FastLED.h>
+
+// T-Dongle S3 APA102 LED configuration
+#define DATA_PIN    40
+#define CLOCK_PIN   39
+#define NUM_LEDS    1
+#define LED_TYPE    APA102
+#define COLOR_ORDER BGR
+
+// LED array
+static CRGB leds[NUM_LEDS];
+
+// Animation state
+static bool detection_active = false;
+static bool heartbeat_active = false;
+static unsigned long last_update = 0;
+static uint8_t flash_count = 0;
+static bool flash_red = true;
+
+void rgb_init() {
+    FastLED.addLeds<LED_TYPE, DATA_PIN, CLOCK_PIN, COLOR_ORDER>(leds, NUM_LEDS);
+    FastLED.setBrightness(50);
+    rgb_off();
+}
+
+void rgb_boot_sequence() {
+    // Quick RGB cycle to show it's working
+    FastLED.setBrightness(100);
+
+    // Red
+    leds[0] = CRGB::Red;
+    FastLED.show();
+    delay(100);
+
+    // Blue
+    leds[0] = CRGB::Blue;
+    FastLED.show();
+    delay(100);
+
+    // Cyan
+    leds[0] = CRGB::Cyan;
+    FastLED.show();
+    delay(100);
+
+    // Off
+    FastLED.setBrightness(50);
+    rgb_off();
+}
+
+void rgb_detection_flash() {
+    // Start rapid red/blue strobe (replaces beeper)
+    detection_active = true;
+    heartbeat_active = false;
+    flash_count = 0;
+    flash_red = true;
+    last_update = millis();
+
+    // Immediate red flash
+    FastLED.setBrightness(255);
+    leds[0] = CRGB::Red;
+    FastLED.show();
+}
+
+void rgb_heartbeat_pulse() {
+    if (!detection_active) {
+        heartbeat_active = true;
+    }
+}
+
+void rgb_set_color(uint8_t r, uint8_t g, uint8_t b) {
+    detection_active = false;
+    heartbeat_active = false;
+    leds[0] = CRGB(r, g, b);
+    FastLED.show();
+}
+
+void rgb_off() {
+    detection_active = false;
+    heartbeat_active = false;
+    leds[0] = CRGB::Black;
+    FastLED.show();
+}
+
+void rgb_update() {
+    unsigned long now = millis();
+
+    if (detection_active) {
+        // Fast red/blue strobe - like police lights (replaces beeper)
+        if (now - last_update >= 50) {  // 50ms = very fast strobe
+            flash_red = !flash_red;
+
+            if (flash_red) {
+                leds[0] = CRGB::Red;
+            } else {
+                leds[0] = CRGB::Blue;
+            }
+            FastLED.setBrightness(255);
+            FastLED.show();
+            last_update = now;
+            flash_count++;
+
+            // Stop strobing after ~3 seconds (60 flashes), go to heartbeat
+            if (flash_count > 60) {
+                detection_active = false;
+                heartbeat_active = true;
+                FastLED.setBrightness(50);
+            }
+        }
+    } else if (heartbeat_active) {
+        // Slow orange pulse for heartbeat (device still in range)
+        if (now - last_update >= 500) {
+            static bool pulse_on = false;
+            pulse_on = !pulse_on;
+
+            if (pulse_on) {
+                leds[0] = CRGB(255, 100, 0);  // Orange
+                FastLED.setBrightness(80);
+            } else {
+                leds[0] = CRGB(255, 50, 0);  // Dim orange
+                FastLED.setBrightness(30);
+            }
+            FastLED.show();
+            last_update = now;
+        }
+    }
+}
+
+#endif // BOARD_T_DONGLE_S3

--- a/src/rgb_led.h
+++ b/src/rgb_led.h
@@ -1,0 +1,30 @@
+#ifndef RGB_LED_H
+#define RGB_LED_H
+
+// RGB LED module for T-Dongle S3 only
+// This file is only included when BOARD_T_DONGLE_S3 is defined
+
+#include <Arduino.h>
+
+// Initialize the RGB LED
+void rgb_init();
+
+// Boot sequence animation
+void rgb_boot_sequence();
+
+// Flash red/blue for detection alert (replaces beeper)
+void rgb_detection_flash();
+
+// Pulse while device in range (heartbeat)
+void rgb_heartbeat_pulse();
+
+// Set specific color
+void rgb_set_color(uint8_t r, uint8_t g, uint8_t b);
+
+// Turn off LED
+void rgb_off();
+
+// Update LED state (call from loop for animations)
+void rgb_update();
+
+#endif // RGB_LED_H


### PR DESCRIPTION
Adds support for T-Dongle S3 (ESP32 USB dongle) with required libraries and build flags. Other hardware should be unaffected.

There's no buzzer (unless you add one via GPIO) but they do have a TFT screen and RGB LEDs, so this is kind of a silent/visual version of the flock-you for the hearing impaired.

Not really suggesting this gets merged since I don't think this repo is really intended for multiple hardware sets. Can just close this PR and leave it as a breadcrumb if you like. Just thought someone might find it useful 😄:

<img width="310" height="170" alt="image" src="https://github.com/user-attachments/assets/7341dcff-a24e-46d4-adf8-f04673b3bb88" />
