### PR TITLE
Fix compile error

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,6 +10,7 @@ board_build.psram_type = opi
 lib_deps = 
     h2zero/NimBLE-Arduino@^1.4.0
     bblanchon/ArduinoJson@^6.21.0
+lib_ignore = esp_mbedtls_esp8266
 build_flags = 
     -DARDUINO_USB_MODE=1
     -DARDUINO_USB_CDC_ON_BOOT=1
@@ -27,6 +28,7 @@ board_build.psram_type = opi
 lib_deps = 
     h2zero/NimBLE-Arduino@^1.4.0
     bblanchon/ArduinoJson@^6.21.0
+lib_ignore = esp_mbedtls_esp8266
 build_flags = 
     -DARDUINO_USB_MODE=1
     -DARDUINO_USB_CDC_ON_BOOT=1


### PR DESCRIPTION
## Problem:

I'm unable to compile due to error about `mbedtls_internal_sha512_process`

```
platformio --version
PlatformIO Core, version 6.1.18
```

`platformio run -e xiao_esp32s3`

```bash
/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/mbedtls/port/sha/dma/esp_sha512.c:105: multiple definition of `mbedtls_sha512_clone'; .pio/build/xiao_esp32s3/libd45/esp_mbedtls_esp8266/sha512.c.o:/Users/redacted/.platformio/lib/esp_mbedtls_esp8266/mbedtls/library/sha512.c:122: first defined here
/Users/redacted/.platformio/packages/toolchain-xtensa-esp-elf/bin/../lib/gcc/xtensa-esp-elf/14.2.0/../../../../xtensa-esp-elf/bin/ld: /Users/redacted/.platformio/packages/framework-arduinoespressif32-libs/esp32s3/lib/libmbedcrypto.a(esp_sha512.c.obj): in function `mbedtls_internal_sha512_process':
/home/runner/work/esp32-arduino-lib-builder/esp32-arduino-lib-builder/esp-idf/components/mbedtls/port/sha/dma/esp_sha512.c:157: multiple definition of `mbedtls_internal_sha512_process'; .pio/build/xiao_esp32s3/libd45/esp_mbedtls_esp8266/sha512.c.o:/Users/redacted/.platformio/lib/esp_mbedtls_esp8266/mbedtls/library/sha512.c:239: first defined here
collect2: error: ld returned 1 exit status
*** [.pio/build/xiao_esp32s3/firmware.elf] Error 1
```

## Solution

Add lib_ignore for mbedtls

`lib_ignore = esp_mbedtls_esp8266`

## Before

```
============================== [FAILED] Took 20.82 seconds ==============================

Environment    Status    Duration
-------------  --------  ------------
xiao_esp32s3   FAILED    00:00:20.824
========================= 1 failed, 0 succeeded in 00:00:20.824 =========================
```

## After

```
============================= [SUCCESS] Took 18.37 seconds =============================

Environment    Status    Duration
-------------  --------  ------------
xiao_esp32s3   SUCCESS   00:00:18.366
============================== 1 succeeded in 00:00:18.366 ==============================
```