### PR TITLE
Add support for DOIT ESP32 DEVKIT V1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ GPIO3 (D2)  ---> Positive (+)
 GND         ---> Negative (-)
 ```
 
+### Option 3: DOIT ESP32 DEVKITV1
+- **Microcontroller**: DOIT ESP32 DEVKIT V1
+- **Buzzer**: 3V buzzer connected to GPIO25 (D25)
+- **Power**: Micro USB cable for programming and power
+
+#### Wiring for DEVKITV1
+```
+DOIT ESP32 DEVKITV1    Buzzer
+GPIO25 (D25)      ---> Positive (+)
+GND               ---> Negative (-)
+```
+
 ## Installation
 
 ### Prerequisites

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,3 +31,18 @@ build_flags =
     -DARDUINO_USB_MODE=1
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DCONFIG_BT_NIMBLE_ENABLED=1
+
+[env:esp32doit-devkit-v1]
+platform = espressif32
+board = esp32doit-devkit-v1
+framework = arduino
+monitor_speed = 115200
+board_build.flash_size = 4MB
+board_build.flash_mode = qio
+board_build.partitions = huge_app.csv
+lib_deps =
+    h2zero/NimBLE-Arduino@^1.4.0
+    bblanchon/ArduinoJson@^6.21.0
+build_flags =
+    -DCONFIG_BT_NIMBLE_ENABLED=1
+    -DBUZZER_PIN=4

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,9 @@
 // ============================================================================
 
 // Hardware Configuration
+#ifndef BUZZER_PIN // Allow BUZZER_PIN to be overwritten by build arguments
 #define BUZZER_PIN 3  // GPIO3 (D2) - PWM capable pin on Xiao ESP32 S3
+#endif
 
 // Audio Configuration
 #define LOW_FREQ 200      // Boot sequence - low pitch


### PR DESCRIPTION
I ran the upload and am happy to report it is working as expected.

One change I had to make was allowing for an overwrite of the `BUZZER_PIN`. `platformio.ini` entries can be given a build argument of `-DBUZZER_PIN`. I opted for this because GPIO4 is utilized for a few other purposes. GPIO25 seemed less likely to be used (especially since I don't think this project will ever need ethernet).