### PR TITLE
dashboard: stop Export/Import dropdowns being clipped or covered

### DIFF
--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -907,13 +907,23 @@
             background: rgba(22, 29, 38, 0.8);
             border-radius: 12px;
             box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-            overflow: hidden;
+            /* No overflow:hidden here: the Export/Import dropdowns are
+               absolutely positioned inside the header and must be able to
+               hang below a short container (e.g. a single detection).
+               Corner rounding is done on the header and list instead. */
+            overflow: visible;
+            /* backdrop-filter makes this a stacking context, so the dropdown's
+               z-index only competes inside it. Lift the whole container above
+               the map/terminal siblings so an open menu is not painted over. */
+            position: relative;
+            z-index: 2;
             border: 1px solid var(--accent);
             backdrop-filter: blur(10px);
         }
 
         .detections-header {
             background: rgba(17, 22, 29, 0.9);
+            border-radius: 12px 12px 0 0;
             padding: 1rem;
             border-bottom: 1px solid var(--accent);
             display: flex;
@@ -930,6 +940,7 @@
 
         .detections-list {
             max-height: 600px;
+            border-radius: 0 0 12px 12px;
             overflow-y: auto;
             scrollbar-width: thin;
             scrollbar-color: var(--accent) var(--surface-2);
@@ -1853,6 +1864,11 @@
             border-bottom: none;
         }
 
+        /* Header carries the corner radius now; round all four when collapsed. */
+        .detections-container.collapsed .detections-header {
+            border-radius: 12px;
+        }
+
         .map-container, .serial-terminal-container, .oui-search-container {
             margin-bottom: 1.25rem;
         }
@@ -2264,6 +2280,17 @@
 
             .export-dropdown { flex: 1 1 auto; }
             .export-dropdown .export-btn { width: 100%; }
+            /* Narrow buttons + right-anchored 160px menus pushed the left-hand
+               (Export) menu past the viewport edge. Anchor each menu to its
+               own button's left edge and let it grow only as wide as needed,
+               capped so it never leaves the screen. */
+            .export-dropdown .export-dropdown-content {
+                left: 0;
+                right: auto;
+                min-width: 100%;
+                width: max-content;
+                max-width: calc(100vw - 2rem);
+            }
 
             /* Detection cards keep their two rows; the right-hand cluster
                wraps under rather than squeezing the MAC. */


### PR DESCRIPTION
Fixes #53.

With one detection in the list, the Export/Import dropdowns were clipped after the first item and painted over by the Detection Map. On phone widths the Export menu also ran off the left edge.

## Changes (CSS only, `api/templates/index.html`)

- `.detections-container`: drop `overflow: hidden`. Corner rounding moves onto `.detections-header` (top corners) and `.detections-list` (bottom corners), and the header rounds all four corners when the panel is collapsed. Visual result is unchanged.
- `.detections-container`: add `position: relative; z-index: 2`. The container's `backdrop-filter` already makes it a stacking context, so the menu's `z-index` only competed inside it; lifting the container puts an open menu above the map/terminal siblings.
- Mobile media query: anchor each menu to its own button's left edge (`left: 0; right: auto`), size it `max-content` with `min-width: 100%`, and cap it at `calc(100vw - 2rem)` so it never leaves the viewport.

## Verification

Playwright against this branch, single test detection, checking every menu item is the element under its own midpoint:

| Viewport | Import items reachable | Export items reachable |
|---|---|---|
| 1200 px, before | 1 / 3 | 2 / 4 |
| 1200 px, after | 3 / 3 | 4 / 4 |
| 390 px, before | 3 / 3 | 0 / 4 (off-screen) |
| 390 px, after | 3 / 3 | 4 / 4 |

After, desktop:

![Import dropdown fully visible](https://raw.githubusercontent.com/bandrel/flock-you/screenshots/dropdown-clipping/upstream-clip-after.png)

After, 390 px:

![Export dropdown within viewport on mobile](https://raw.githubusercontent.com/bandrel/flock-you/screenshots/dropdown-clipping/upstream-mobile-after.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
