### PR TITLE
Dashboard: pull on-device session over USB and persist the session list

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Detections carry `detection_method` and `detection_tier`; the dashboard also kee
 - `GET /api/flock/config` — current per-tier beep state, and asks the device to re-report
 - `POST /api/flock/beep` — `{"tier": 0-4, "enabled": bool}` to mute one tier, or `{"mask": 0-31}` to set all five at once
 
+- `POST /api/flock/dump_session` — `{"source": "live"}` (default) or `{"source": "prev"}`; asks the device to stream its detection table so a standalone run can be pulled into the dashboard after the fact
+
 Commands go to the device as one JSON line over the same USB CDC link the detections come back on. The device answers with an `{"event":"config"}` line, which Flask relays to the browser over the `device_config` socket event — so the switches follow the device's actual state, not the click.
 
 ### GPS wardriving
@@ -317,6 +319,8 @@ pio device monitor
 **With USB + Flask running:** same thing, plus every detection streams live to the dashboard as a JSON line. Flask adds GPS (if configured) and deduplicates across MAC, building the wardriving map as you move.
 
 Both modes work simultaneously — the SPIFFS write path doesn't care if a host is listening.
+
+**Pulling an offline run into the dashboard:** plug the device in afterwards, connect it in the dashboard, and use **Import → Pull current session from device** (the table accumulated since this boot) or **Pull previous session from device** (`/prev_session.json`, the run before the last power cycle). The device answers `{"cmd":"dump_session","source":"live|prev"}` with a `session_begin` line, one `session_det` line per device in the same shape as the SPIFFS records, and a `session_end` line; Flask imports each record as it arrives and reports progress over the `session_dump` socket event. Records carry the on-device hit count but not wall-clock time (the device has no RTC), so imported detections are timestamped at import and get no GPS match.
 
 ---
 

--- a/api/README.md
+++ b/api/README.md
@@ -78,6 +78,7 @@ The GPS header row has a **source** dropdown with two options:
 
 ### Detection Management
 - `GET /api/detections` - Get all detections (with optional filtering)
+- `POST /api/flock/dump_session` - Ask the connected device to stream its stored detection table (`{"source": "live"|"prev"}`); records are imported as they arrive
 - `POST /api/detections` - Add new detection from Flock You device
 - `POST /api/clear` - Clear all detections
 

--- a/api/README.md
+++ b/api/README.md
@@ -18,6 +18,9 @@ A Flask-based web dashboard for real-time monitoring and analysis of Flock Safet
 - **Location Tagging**: Each detection can include GPS coordinates
 - **Satellite Information**: Display GPS fix quality and satellite count
 
+### Persistence
+Both detection lists live in `api/data/` as pickles. `cumulative_detections.pkl` is the all-time history; `session_detections.pkl` is the current session, saved on every change and reloaded on startup, so restarting the server does not empty the Detections list. The session only resets when you click **Clear**.
+
 ### Data Export
 - **CSV Export**: Download detection data in CSV format
 - **KML Export**: Generate Google Earth compatible KML files

--- a/api/flockyou.py
+++ b/api/flockyou.py
@@ -77,6 +77,7 @@ gps_source = None              # 'serial' | 'gpsd' | None
 # Data storage paths
 DATA_DIR = Path('data')
 CUMULATIVE_DATA_FILE = DATA_DIR / 'cumulative_detections.pkl'
+SESSION_DATA_FILE = DATA_DIR / 'session_detections.pkl'
 SETTINGS_FILE = DATA_DIR / 'settings.json'
 
 # Ensure data directory exists
@@ -105,6 +106,34 @@ def save_cumulative_detections():
         print(f"Saved {len(cumulative_detections)} cumulative detections")
     except Exception as e:
         print(f"Error saving cumulative detections: {e}")
+
+def load_session_detections():
+    """Restore the current session list so a dashboard restart does not wipe
+    it. The session only resets when the user clicks Clear."""
+    global detections, next_detection_id, session_start_time
+    try:
+        if SESSION_DATA_FILE.exists():
+            with open(SESSION_DATA_FILE, 'rb') as f:
+                state = pickle.load(f)
+            detections = state.get('detections', [])
+            next_detection_id = max([d.get('id', 0) for d in detections] + [0]) + 1
+            start = state.get('session_start_time')
+            if start:
+                session_start_time = datetime.fromisoformat(start)
+            print(f"Loaded {len(detections)} session detections "
+                  f"(session started {session_start_time.isoformat(timespec='seconds')})")
+    except Exception as e:
+        print(f"Error loading session detections: {e}")
+        detections = []
+
+def save_session_detections():
+    """Persist the current session list; written on every change."""
+    try:
+        with open(SESSION_DATA_FILE, 'wb') as f:
+            pickle.dump({'detections': detections,
+                         'session_start_time': session_start_time.isoformat()}, f)
+    except Exception as e:
+        print(f"Error saving session detections: {e}")
 
 def load_settings():
     """Load settings from disk"""
@@ -702,6 +731,7 @@ def add_detection_from_serial(data):
                 cum_detection.update(existing_detection)
                 break
         save_cumulative_detections()
+        save_session_detections()
         
         # Emit updated detection
         safe_socket_emit('detection_updated', existing_detection)
@@ -725,6 +755,7 @@ def add_detection_from_serial(data):
         # Add to cumulative detections
         cumulative_detections.append(data.copy())
         save_cumulative_detections()
+        save_session_detections()
         
         # Emit to connected clients
         safe_socket_emit('new_detection', data)
@@ -1728,6 +1759,7 @@ def clear_detections():
     detections.clear()
     next_detection_id = 1  # Reset ID counter
     session_start_time = datetime.now()  # Reset session start time
+    save_session_detections()
     safe_socket_emit('detections_cleared', {})
     return jsonify({'status': 'success', 'message': 'Session detections cleared'})
 
@@ -1781,6 +1813,7 @@ def update_detection_alias():
     for detection in detections:
         if detection.get('id') == detection_id:
             detection['alias'] = alias
+            save_session_detections()
             # Emit update to all clients
             safe_socket_emit('detection_updated', detection)
             return jsonify({'status': 'success', 'message': 'Alias updated'})
@@ -2062,6 +2095,7 @@ def initialize_app():
 
     load_oui_database()
     load_cumulative_detections()
+    load_session_detections()
     load_settings()
 
     # Wire the BLE blueprint to the shared detection sink so BLE hits (live

--- a/api/flockyou.py
+++ b/api/flockyou.py
@@ -41,6 +41,8 @@ serial_connection = None
 gps_enabled = False
 flock_device_connected = False
 flock_device_port = None
+# Progress of an in-flight dump_session transfer from the device.
+session_dump = {'active': False, 'source': None, 'expected': 0, 'received': 0}
 flock_serial_connection = None
 oui_database = {}
 serial_data_buffer = []
@@ -399,7 +401,26 @@ def flock_reader():
                             # Try to parse as detection data
                             try:
                                 data = json.loads(line)
-                                if data.get('event') == 'config':
+                                event = data.get('event')
+                                if event == 'session_begin':
+                                    session_dump.update(active=True, source=data.get('source'),
+                                                        expected=data.get('count', 0), received=0)
+                                    safe_socket_emit('session_dump', {'phase': 'begin', **session_dump})
+                                elif event == 'session_det':
+                                    import_detection_item(data)
+                                    session_dump['received'] += 1
+                                    if session_dump['received'] % 10 == 0:
+                                        safe_socket_emit('session_dump', {'phase': 'progress', **session_dump})
+                                elif event == 'session_end':
+                                    session_dump['active'] = False
+                                    safe_socket_emit('session_dump', {'phase': 'end', **session_dump,
+                                                                      'device_count': data.get('count')})
+                                    print(f"Session dump ({session_dump['source']}): imported {session_dump['received']} detections")
+                                elif event == 'session_error':
+                                    session_dump['active'] = False
+                                    safe_socket_emit('session_dump', {'phase': 'error', **session_dump,
+                                                                      'error': data.get('error', 'unknown')})
+                                elif event == 'config':
                                     # Device reporting its per-tier beep mask.
                                     globals()['device_config'] = data
                                     safe_socket_emit('device_config', data)
@@ -690,7 +711,8 @@ def add_detection_from_serial(data):
         data['id'] = next_detection_id
         next_detection_id += 1
         data['alias'] = ''  # Empty alias by default
-        data['detection_count'] = 1
+        # Imported records (file import, dump_session) carry the device's hit count.
+        data['detection_count'] = int(data.get('detection_count') or 1)
         data['first_seen'] = datetime.now().isoformat()
         data['last_seen'] = datetime.now().isoformat()
         data['detection_tier'] = method_tier(data)
@@ -1135,6 +1157,26 @@ def set_flock_beep():
     return jsonify({'status': 'success', 'message': msg})
 
 
+@app.route('/api/flock/dump_session', methods=['POST'])
+def dump_flock_session():
+    """Ask the device to stream its detection table over USB.
+
+    Body: {"source": "live"} (default) for the table accumulated since boot,
+       or {"source": "prev"} for /prev_session.json, the previous boot's run.
+    The device answers with session_begin / session_det / session_end lines;
+    flock_reader() imports each record and relays progress on the
+    session_dump socket event.
+    """
+    body = request.get_json(silent=True) or {}
+    source = body.get('source', 'live')
+    if source not in ('live', 'prev'):
+        return jsonify({'status': 'error', 'message': 'source must be "live" or "prev"'}), 400
+    ok, msg = send_device_command({'cmd': 'dump_session', 'source': source})
+    if not ok:
+        return jsonify({'status': 'error', 'message': msg}), 503
+    return jsonify({'status': 'success', 'message': f'Requested {source} session from device'})
+
+
 @app.route('/api/status', methods=['GET'])
 def get_status():
     """Get connection status of both devices"""
@@ -1386,6 +1428,48 @@ def export_kml():
     
     return send_file(filepath, as_attachment=True, download_name=filename)
 
+def import_detection_item(item):
+    """Map one ESP32-format detection record onto the Flask detection schema
+    and add it. Accepts both the on-device session keys (mac, method, tier,
+    count, ssid) and dashboard-export keys (mac_address, detection_method...).
+    Shared by the JSON file import and the live dump_session stream."""
+    # Map ESP32 export fields to Flask detection format
+    method = normalize_method(item.get('method', item.get('detection_method')))
+    data = {
+        'detection_method': method,
+        # This firmware is WiFi-only; the old hardcoded bluetooth_le
+        # mislabelled every imported record.
+        'protocol': item.get('protocol', 'wifi_2_4ghz'),
+        'mac_address': item.get('mac', item.get('mac_address', '')),
+        'device_name': item.get('name', item.get('device_name', '')),
+        'rssi': item.get('rssi', 0),
+        'detection_count': item.get('count', item.get('detection_count', 1)),
+        # Trust an explicit tier from the device, else derive it.
+        'detection_tier': item.get('tier', item.get('detection_tier',
+                                                    METHOD_TIERS.get(method, 0))),
+    }
+    if item.get('channel') is not None:
+        data['channel'] = item['channel']
+    if item.get('ssid'):
+        data['ssid'] = item['ssid']
+
+    # GPS fields from ESP32 wardriving export
+    gps_obj = item.get('gps')
+    if gps_obj and (gps_obj.get('lat') or gps_obj.get('latitude')):
+        data['gps'] = {
+            'latitude': gps_obj.get('lat', gps_obj.get('latitude')),
+            'longitude': gps_obj.get('lon', gps_obj.get('longitude')),
+            'altitude': gps_obj.get('alt', gps_obj.get('altitude', 0)),
+            'fix_quality': 1,
+            'match_quality': 'esp32_phone_gps',
+            'time_diff': 0,
+        }
+        if gps_obj.get('acc') is not None:
+            data['gps']['accuracy'] = gps_obj['acc']
+
+    add_detection_from_serial(data)
+
+
 @app.route('/api/import/json', methods=['POST'])
 def import_json():
     """Import detections from a JSON file (exported from ESP32 Flock-You dashboard)"""
@@ -1407,41 +1491,7 @@ def import_json():
 
         count = 0
         for item in imported:
-            # Map ESP32 export fields to Flask detection format
-            method = normalize_method(item.get('method', item.get('detection_method')))
-            data = {
-                'detection_method': method,
-                # This firmware is WiFi-only; the old hardcoded bluetooth_le
-                # mislabelled every imported record.
-                'protocol': item.get('protocol', 'wifi_2_4ghz'),
-                'mac_address': item.get('mac', item.get('mac_address', '')),
-                'device_name': item.get('name', item.get('device_name', '')),
-                'rssi': item.get('rssi', 0),
-                'detection_count': item.get('count', item.get('detection_count', 1)),
-                # Trust an explicit tier from the device, else derive it.
-                'detection_tier': item.get('tier', item.get('detection_tier',
-                                                            METHOD_TIERS.get(method, 0))),
-            }
-            if item.get('channel') is not None:
-                data['channel'] = item['channel']
-            if item.get('ssid'):
-                data['ssid'] = item['ssid']
-
-            # GPS fields from ESP32 wardriving export
-            gps_obj = item.get('gps')
-            if gps_obj and (gps_obj.get('lat') or gps_obj.get('latitude')):
-                data['gps'] = {
-                    'latitude': gps_obj.get('lat', gps_obj.get('latitude')),
-                    'longitude': gps_obj.get('lon', gps_obj.get('longitude')),
-                    'altitude': gps_obj.get('alt', gps_obj.get('altitude', 0)),
-                    'fix_quality': 1,
-                    'match_quality': 'esp32_phone_gps',
-                    'time_diff': 0,
-                }
-                if gps_obj.get('acc') is not None:
-                    data['gps']['accuracy'] = gps_obj['acc']
-
-            add_detection_from_serial(data)
+            import_detection_item(item)
             count += 1
 
         print(f"Imported {count} detections from JSON file: {file.filename}")

--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -2450,6 +2450,8 @@
                             <a href="#" onclick="importFile('json')">Import JSON (from ESP32)</a>
                             <a href="#" onclick="importFile('csv')">Import CSV (from ESP32)</a>
                             <a href="#" onclick="importFile('kml')">Import KML (from ESP32)</a>
+                            <a href="#" onclick="pullDeviceSession('live')">Pull current session from device</a>
+                            <a href="#" onclick="pullDeviceSession('prev')">Pull previous session from device</a>
                         </div>
                     </div>
                     <input type="file" id="importFileInput" accept=".json,.csv,.kml" style="display:none" onchange="handleImportFile()">
@@ -3548,6 +3550,34 @@
             // Reset input so same file can be re-selected
             input.value = '';
         }
+
+        // Ask the connected device to stream its detection table over USB.
+        // Flask imports each record as it arrives and reports progress on
+        // the session_dump socket event.
+        function pullDeviceSession(source) {
+            closeImportDropdown();
+            fetch('/api/flock/dump_session', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ source: source })
+            })
+            .then(r => r.json())
+            .then(data => {
+                if (data.status !== 'success') alert('Session pull failed: ' + data.message);
+            })
+            .catch(err => alert('Session pull failed: ' + err.message));
+        }
+
+        socket.on('session_dump', function(msg) {
+            if (msg.phase === 'end') {
+                alert('Imported ' + msg.received + ' detections from device (' + msg.source + ' session)');
+                loadDetections();
+                loadCumulativeDetections();
+                updateStats();
+            } else if (msg.phase === 'error') {
+                alert('Device session pull failed: ' + msg.error);
+            }
+        });
 
         // Close dropdowns when clicking outside
         document.addEventListener('click', function(event) {

--- a/main.cpp
+++ b/main.cpp
@@ -1018,6 +1018,88 @@ static void fySaveBeepMask() {
   fyPrefs.end();
 }
 
+// ------------------------------------------------------------
+// Session dump over USB (host command "dump_session")
+//
+// Streams the detection table to the host as line-delimited JSON so the
+// Flask dashboard can ingest a standalone (offline) run after the fact:
+//   {"event":"session_begin","source":"live|prev","count":N}
+//   {"event":"session_det", <fySerializeDet fields>}   x N
+//   {"event":"session_end","source":"live|prev","count":N}
+// "live" is the in-RAM table for this boot; "prev" is /prev_session.json,
+// the previous boot's table promoted at startup. Live detections may
+// interleave with the dump; the host tells them apart by the event key.
+// ------------------------------------------------------------
+
+static void fyDumpLiveSession() {
+  char line[384];
+  dualPrintf("{\"event\":\"session_begin\",\"source\":\"live\",\"count\":%d}\n", fyDetCount);
+  int sent = 0;
+  for (int i = 0; i < fyDetCount; i++) {
+    size_t n = fySerializeDet(fyDet[i], line, sizeof(line));
+    if (n < 2) continue;
+    // fySerializeDet yields "{...}"; splice the event key in after the '{'.
+    Serial.print("{\"event\":\"session_det\",");
+    Serial.write((const uint8_t*)line + 1, n - 1);
+    Serial.print('\n');
+    sent++;
+    if ((i & 7) == 7) delay(1);   // let USB CDC drain
+  }
+  dualPrintf("{\"event\":\"session_end\",\"source\":\"live\",\"count\":%d}\n", sent);
+}
+
+// Stream the JSON array on line 2 of a session file, one top-level object
+// per output line. Tracks string/escape state so braces inside an SSID
+// don't confuse the depth counter.
+static void fyDumpFileSession(const char* path, const char* source) {
+  if (!fySpiffsReady || !fyValidateSessionFile(path)) {
+    dualPrintf("{\"event\":\"session_error\",\"source\":\"%s\",\"error\":\"no valid session file\"}\n", source);
+    return;
+  }
+  File f = SPIFFS.open(path, "r");
+  if (!f) {
+    dualPrintf("{\"event\":\"session_error\",\"source\":\"%s\",\"error\":\"open failed\"}\n", source);
+    return;
+  }
+  String hdr = f.readStringUntil('\n');
+  int count = -1;
+  const char* cp = strstr(hdr.c_str(), "\"count\":");
+  if (cp) sscanf(cp + 8, "%d", &count);
+  dualPrintf("{\"event\":\"session_begin\",\"source\":\"%s\",\"count\":%d}\n", source, count);
+
+  int  depth = 0, sent = 0;
+  bool inStr = false, esc = false;
+  while (f.available()) {
+    int c = f.read();
+    if (c < 0) break;
+    if (depth == 0) {
+      if (c == '{') {
+        Serial.print("{\"event\":\"session_det\",");
+        depth = 1;
+      }
+      continue;   // skip '[' ',' ']' whitespace between objects
+    }
+    Serial.write((uint8_t)c);
+    if (inStr) {
+      if (esc)             esc = false;
+      else if (c == '\\')  esc = true;
+      else if (c == '"')   inStr = false;
+      continue;
+    }
+    if      (c == '"') inStr = true;
+    else if (c == '{') depth++;
+    else if (c == '}') {
+      if (--depth == 0) {
+        Serial.print('\n');
+        sent++;
+        if ((sent & 7) == 0) delay(1);
+      }
+    }
+  }
+  f.close();
+  dualPrintf("{\"event\":\"session_end\",\"source\":\"%s\",\"count\":%d}\n", source, sent);
+}
+
 static void emitConfigJSON() {
   char tiers[320];
   size_t o = 0;
@@ -1038,6 +1120,12 @@ static void emitConfigJSON() {
 
 static void handleCommandLine(const char* line) {
   if (!strstr(line, "\"cmd\"")) return;
+
+  if (strstr(line, "\"dump_session\"")) {
+    if (strstr(line, "\"prev\"")) fyDumpFileSession(FY_PREV_FILE, "prev");
+    else                          fyDumpLiveSession();
+    return;
+  }
 
   if (strstr(line, "\"get_config\"")) {
     emitConfigJSON();


### PR DESCRIPTION
Closes #55.

Lets a standalone (unplugged) run be pulled into the dashboard afterwards, and makes the session list survive a dashboard restart.

## Commits

**1. `dump_session`: pull the on-device detection table into the dashboard over USB**

Firmware: new host command `{"cmd":"dump_session","source":"live|prev"}`. `live` streams the in-RAM table for this boot; `prev` streams `/prev_session.json`. Output is line-delimited so the existing reader handles it: `session_begin`, one `session_det` per record (same fields as the SPIFFS records, via `fySerializeDet()`), then `session_end`. The `prev` path parses the on-disk JSON array with a small brace/string-state walker so it never needs to hold the whole file in RAM. A `session_error` line is emitted if no valid file exists.

Flask: the per-record mapping in `/api/import/json` is factored into `import_detection_item()` and reused by `flock_reader()` for `session_det` lines. New `POST /api/flock/dump_session` issues the command; progress is relayed on a `session_dump` socket event. Imported records now keep the device's hit count instead of being reset to 1 (this also fixes the existing JSON file import).

Dashboard: **Import** menu gains "Pull current session from device" and "Pull previous session from device". An alert reports the count on completion and the lists refresh.

READMEs updated in both places.

**2. Persist the session detection list across restarts**

Session detections were in-memory only, so every dashboard restart emptied the Detections panel while the cumulative history survived. The list plus session start time is now saved to `data/session_detections.pkl` on every change and reloaded at startup; the id counter resumes from the highest restored id. **Clear** still wipes it. `data/` is already gitignored.

## Verification

- Firmware builds for `xiao_esp32s3`. Flashed to an ESP32-S3 running this branch: `dump_session live` after a fresh boot returned begin/end with count 0; `dump_session prev` streamed the real stored record (one MAC, 306 hits) and terminated cleanly.
- Flask tested end to end with a fake device on a pty: command received, two `session_det` records imported (including an SSID containing `{}` and `"`), `session_dump` events emitted, records visible in `/api/detections`.
- Persistence: two detections and an alias survived a server restart with the same ids and session start time; a new detection after restart got the next id; Clear followed by restart came back empty.

## Caveat

The device has no RTC, so pulled records are timestamped at import time and get no GPS match. Documented in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
