### PR TITLE
dashboard: drop call to removed setFlockExtraControls

### DIFF
--- a/api/templates/index.html
+++ b/api/templates/index.html
@@ -3247,7 +3247,6 @@
             document.getElementById('connectFlockBtn').style.display    = connected ? 'none' : 'inline-block';
             document.getElementById('disconnectFlockBtn').style.display = connected ? 'inline-block' : 'none';
             setFlockControlsLocked(!!connected);
-            setFlockExtraControls(!!connected);
         }
 
         function updateGpsStatus(connected) {


### PR DESCRIPTION
Fixes #57.

`updateFlockStatus()` still called `setFlockExtraControls()`, a helper deleted with the CMD:* UI in 0793fba. Every `/api/status` poll threw a `ReferenceError`, and because the call sits inside the `loadStatus()` success handler, the GPS restore that follows it never ran on page load.

One-line removal. Verified with Playwright against this branch: the browser console is clean across several poll cycles, where `main` logs the error on load and every 5 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
